### PR TITLE
check p_load_dates table instead of p_cpu_usage_agg_report

### DIFF
--- a/dbcheck/tests/sanity_checks.yml
+++ b/dbcheck/tests/sanity_checks.yml
@@ -42,7 +42,7 @@
     Count: 2160
 -
   Description: "p_load_dates should contain records no older than 36 hours"
-  Sql: "select coalesce(extract('epoch' from (now() - (max(load_date) + interval'23:59'))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_load_dates where load_date >= now()::date - 2;"
+  Sql: "select coalesce(extract('epoch' from (now() at time zone 'utc' - (max(load_date) + interval'23:59'))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_load_dates where load_date >= (now() at time zone 'utc')::date - 2"
   Result:
     Operation: "<"
     Count: 2160

--- a/dbcheck/tests/sanity_checks.yml
+++ b/dbcheck/tests/sanity_checks.yml
@@ -42,7 +42,7 @@
     Count: 2160
 -
   Description: "p_load_dates should contain records no older than 60 hours"
-  Sql: "select coalesce(extract('epoch' from (now() at time zone 'utc' - max(load_date))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_load_dates where load_date >= (now() at time zone 'utc')::date - 2"
+  Sql: "select coalesce(extract('epoch' from (now() at time zone 'utc' - max(load_date))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_load_dates"
   Result:
     Operation: "<"
     Count: 3600

--- a/dbcheck/tests/sanity_checks.yml
+++ b/dbcheck/tests/sanity_checks.yml
@@ -41,11 +41,11 @@
     Operation: "<"
     Count: 2160
 -
-  Description: "p_load_dates should contain records no older than 36 hours"
-  Sql: "select coalesce(extract('epoch' from (now() at time zone 'utc' - (max(load_date) + interval'23:59'))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_load_dates where load_date >= (now() at time zone 'utc')::date - 2"
+  Description: "p_load_dates should contain records no older than 60 hours"
+  Sql: "select coalesce(extract('epoch' from (now() at time zone 'utc' - max(load_date))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_load_dates where load_date >= (now() at time zone 'utc')::date - 2"
   Result:
     Operation: "<"
-    Count: 2160
+    Count: 3600
 -
   Description: "p_cpu_usage_bootstrap_rpt should contain records no older than 3 days"
   Sql: "select coalesce(extract('epoch' from (now() at time zone 'utc' - max(cpu_usage_ts_rounded_15_secs))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_cpu_usage_bootstrap_rpt where cpu_usage_ts_rounded_15_secs >= now()::date -3"

--- a/dbcheck/tests/sanity_checks.yml
+++ b/dbcheck/tests/sanity_checks.yml
@@ -41,8 +41,8 @@
     Operation: "<"
     Count: 2160
 -
-  Description: "p_cpu_usage_agg_report should contain records no older than 36 hours"
-  Sql: "select coalesce(extract('epoch' from (now() at time zone 'utc' - max(timestamp_utc))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_cpu_usage_agg_report where timestamp_utc >= (now() at time zone 'utc')::date - 2"
+  Description: "p_load_dates should contain records no older than 36 hours"
+  Sql: "select coalesce(extract('epoch' from (now() - (max(load_date) + interval'23:59'))) / 60, 9999)::int as no_change_in_minutes, 'NONE' from palette.p_load_dates where load_date >= now()::date - 2;"
   Result:
     Operation: "<"
     Count: 2160


### PR DESCRIPTION
This PR is in connection with the DATA-1186 branch in insight-data-model repository, and shouldn't be merged until it is merged.